### PR TITLE
refactor: disable automerge

### DIFF
--- a/default.json
+++ b/default.json
@@ -53,14 +53,9 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "One week stability period for minor and patch updates",
-      "matchUpdateTypes": ["minor", "patch"],
+      "description": "One week stability period for minor, patch, digest and lockFileMaintenance",
+      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
       "stabilityDays": 7
-    },
-    {
-      "description": "Automerge digest and lock file maintenance",
-      "matchUpdateTypes": ["digest", "lockFileMaintenance"],
-      "automerge": true
     },
     {
       "description": "v prefix workaround for action updates",


### PR DESCRIPTION
Enabling automerge for lock file maintenance is risky if projects don't pin dependencies. Grouping patch and lock file maintenance under the same grouping as minor version updates. Teams can override if they'd like to introduce automerge functionality.