### PR TITLE
fix: disable auto-merge of PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,7 +17,7 @@
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "internalChecksFilter": "strict",
   "packageRules": [
     {


### PR DESCRIPTION
# Summary
Update the default config to disable `platformAutomerge`.  The reason is because the Renovate docs recommend that before enabling this setting, all repositories have branch protection that requires status checks to pass before merging.

With this set to `true` and no branch protection rules, it's possible that a dependency update could be merged before status checks have finished successfully:
https://docs.renovatebot.com/configuration-options/#platformautomerge

# Related
* cds-snc/platform-core-services#118