### PR TITLE
fix: removes automerge type

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,6 @@
     "helpers:pinGitHubActionDigests"
   ],
   "schedule": ["before 3am on Monday"],
-  "automergeType": "pr",
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
Since we don't want automerge on by default we don't need to include the `automergeType` setting.

