### PR TITLE
fix: remove redundant Dependency Dashboard setting

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,7 +14,6 @@
   ],
   "schedule": ["before 3am on Monday"],
   "automergeType": "pr",
-  "dependencyDashboard": true,
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",
   "platformAutomerge": false,


### PR DESCRIPTION
This is already enabled by default in our `extends` block with the use of `config:base`

