### PR TITLE
fix: remove RebaseWhen

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,6 @@
   "automergeType": "pr",
   "dependencyDashboard": true,
   "prCreation": "not-pending",
-  "rebaseWhen": "behind-base-branch",
   "platformAutomerge": false,
   "internalChecksFilter": "strict",
   "packageRules": [


### PR DESCRIPTION
Already included in our base config settings. `:rebaseStalePrs` is set to `behind-base-branch` by default.

