### PR TITLE
Adds PR labels for better search and admin

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,6 +19,7 @@
   "rebaseWhen": "behind-base-branch",
   "platformAutomerge": false,
   "internalChecksFilter": "strict",
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
All PRs created will now have a `dependencies` label to allow devs to easily spot them in their board. Also would be easier to filter and create reports on if PMs need them.

