### PR TITLE
chore: ignore bridgecrewio/checkov-action

### DIFF
--- a/default.json
+++ b/default.json
@@ -22,6 +22,9 @@
   "prBodyNotes": [
     "### Review \n- [ ] Updates have been tested and work \n- [ ] If updates are AWS related, versions match the infrastructure (e.g. Lambda runtime, database, etc.)"
   ],
+  "ignoreDeps": [
+    "bridgecrewio/checkov-action"
+  ],
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
# Summary
Update the config to ignore the bridgecrewio/checkov-action GitHub Action.  The reason for this is that the bridgecrewio GitHub org has an IP allow list that's currently blocking the lookup of this dependency by the Renovate GitHub app's worker.

As a result, Renovate PRs and the dependency dashboard are showing a warning.  An issue has been created with the action authors to see if the IP allow list can be updated.

# Related
* renovatebot/renovate#17826
* bridgecrewio/checkov-action#97
* cds-snc/platform-core-services#118