### PR TITLE
feat: update PIP requirements regex match

### DIFF
--- a/.github/workflows/validate_config.yml
+++ b/.github/workflows/validate_config.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-env:
-  RENOVATE_CONFIG_FILE: default.json
-
 jobs:
   preset:
     runs-on: ubuntu-latest
@@ -24,4 +21,4 @@ jobs:
         run: npm install -g renovate@32.202.3
 
       - name: Validate config 
-        run: renovate renovate-config-validator
+        run: renovate-config-validator default.json

--- a/.github/workflows/validate_config.yml
+++ b/.github/workflows/validate_config.yml
@@ -1,0 +1,27 @@
+name: Validate Renovate config
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  RENOVATE_CONFIG_FILE: default.json
+
+jobs:
+  preset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - name: Install validator
+        run: npm install -g renovate-config-validator
+
+      - name: Validate config 
+        run: npx -p renovate renovate-config-validator

--- a/.github/workflows/validate_config.yml
+++ b/.github/workflows/validate_config.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
       - name: Install validator
-        run: npm install -g renovate-config-validator
+        run: npm install -g renovate@32.202.3
 
       - name: Validate config 
-        run: npx -p renovate renovate-config-validator
+        run: renovate renovate-config-validator

--- a/default.json
+++ b/default.json
@@ -22,8 +22,12 @@
     "### Review \n- [ ] Updates have been tested and work \n- [ ] If updates are AWS related, versions match the infrastructure (e.g. Lambda runtime, database, etc.)"
   ],
   "ignoreDeps": [
-    "bridgecrewio/checkov-action"
+    "bridgecrewio/checkov-action",
+    "public.ecr.aws/lambda/python"
   ],
+  "pip_requirements": {
+    "fileMatch": ["(^|/)([\\w-]*)requirements([\\w-]*)\\.(txt|pip|in)$"]
+  },
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
# Summary
Update how PIP requirements are found to account for files with names like `requirements_for_test.txt` and `requirements.in`.

Add a Renovate config validator action to make sure changes do not break the config file.

Ignore the `public.ecr.aws/lambda/python` Docker image as these cannot be checked without an AWS login.

# Related
* cds-snc/platform-core-services#118