### PR TITLE
fix: use Renovate docker image to validate config

### DIFF
--- a/.github/workflows/validate_config.yml
+++ b/.github/workflows/validate_config.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
-      - name: Install validator
-        run: npm install -g renovate@32.202.3
-
       - name: Validate config 
-        run: renovate-config-validator default.json
+        run: |
+          docker run \
+            --entrypoint=renovate-config-validator \
+            --volume "$(pwd):/tmp" \
+            renovate/renovate:slim /tmp/default.json


### PR DESCRIPTION
# Summary
Switch to using the pre-built Docker image to perform config validation.
This is because the `npm install` was not working consistently with the
Renovate package.