### PR TITLE
fix: revert the `rollbackPrs` config setting

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -137,7 +137,7 @@ Language specific tips and tricks
 ## Gotchas
 - You cannot have different sets of configuration settings across different branches! Your settings will always be taken from the branch that is set as your default branch. You can apply Renovate to scan as many branches as you'd like, just keep in mind you can't have custom settings _per_ branch.
 - Any manual dependency rollbacks that are applied to your code will automatically have any open PRs on that dependency closed. 
-- There are times when a dependency version in use by a project gets removed from the registry. For some registries, existing releases or even whole packages can be removed or "yanked" at any time, while for some registries only very new or unused releases can be removed. rollbackPrs is set to true, which will downgrade to the next-highest release if the current release is no longer found in the registry.
+- There are times when a dependency version in use by a project gets removed from the registry. For some registries, existing releases or even whole packages can be removed or "yanked" at any time, while for some registries only very new or unused releases can be removed. rollbackPrs is set to true for `npm` pacakages, which will downgrade to the next-highest release if the current release is no longer found in the registry.
 
 
 

--- a/default.json
+++ b/default.json
@@ -16,7 +16,6 @@
   "timezone": "America/Montreal",
   "automergeType": "pr",
   "prCreation": "not-pending",
-  "rollbackPrs": true,
   "platformAutomerge": false,
   "internalChecksFilter": "strict",
   "labels": ["Dependencies"],


### PR DESCRIPTION
# Summary
The `rollbackPrs` config setting is causing undesirable behaviour for our pinned GitHub action versions by causing rollbacks on actions pinned to shared tags (like `v2`) as they are updated with new commit SHAs.

# Related
- #24 