### PR TITLE
feat: group all non-major Docker and GitHub Action

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,13 +12,18 @@
     "group:linters",
     "helpers:pinGitHubActionDigests"
   ],
-  "schedule": ["every weekend"],
+  "schedule": [
+    "every weekend"
+  ],
   "timezone": "America/Montreal",
   "automergeType": "pr",
   "prCreation": "not-pending",
   "platformAutomerge": false,
   "internalChecksFilter": "strict",
-  "labels": ["Dependencies"],
+  "labels": [
+    "Dependencies",
+    "Renovate"
+  ],
   "prBodyNotes": [
     "### Review \n- [ ] Updates have been tested and work \n- [ ] If updates are AWS related, versions match the infrastructure (e.g. Lambda runtime, database, etc.)"
   ],
@@ -27,12 +32,18 @@
     "public.ecr.aws/lambda/python"
   ],
   "pip_requirements": {
-    "fileMatch": ["(^|/)([\\w-]*)requirements([\\w-]*)\\.(txt|pip|in)$"]
+    "fileMatch": [
+      "(^|/)([\\w-]*)requirements([\\w-]*)\\.(txt|pip|in)$"
+    ]
   },
   "packageRules": [
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["python"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "python"
+      ],
       "versioning": "pep440"
     },
     {
@@ -58,31 +69,81 @@
       "groupSlug": "all-minor"
     },
     {
+      "description": "Group all non-major GitHub actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major github action dependencies",
+      "groupSlug": "all-non-major-github-action"
+    },
+    {
+      "description": "Group all non-major Docker images",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major docker images",
+      "groupSlug": "all-non-major-docker-images"
+    },
+    {
       "description": "Require dashboard approval for major updates",
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "dependencyDashboardApproval": true
     },
     {
       "description": "One week stability period for minor, patch, digest and lockFileMaintenance",
-      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "lockFileMaintenance"
+      ],
       "stabilityDays": 7
     },
     {
       "description": "v prefix workaround for action updates",
-      "matchDepTypes": ["action"],
+      "matchDepTypes": [
+        "action"
+      ],
       "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },
     {
       "description": "Group prettier packages",
-      "matchPackageNames": ["prettier"],
-      "matchPackagePatterns": ["^@prettier\\/", "^prettier-plugin-"],
+      "matchPackageNames": [
+        "prettier"
+      ],
+      "matchPackagePatterns": [
+        "^@prettier\\/",
+        "^prettier-plugin-"
+      ],
       "groupName": "prettier packages"
     },
     {
       "description": "Require approval for aws-sdk as it updates too often",
-      "matchPackageNames": ["aws-sdk"],
-      "matchPackagePatterns": ["^@aws-sdk\\/"],
+      "matchPackageNames": [
+        "aws-sdk"
+      ],
+      "matchPackagePatterns": [
+        "^@aws-sdk\\/"
+      ],
       "dependencyDashboardApproval": true
     }
   ]


### PR DESCRIPTION
# Summary
Update the config so that all non-major Docker and GitHub Action updates are grouped together.  In testing on Scan Files and the Forms repos this is working nicely.

Also updates the labels to add a "Renovate" label to make it easier to query the GitHub API for Renovate PRs.

# Related
- Closes #28 