### PR TITLE
feat: add `no-grouping` Renovate config

### DIFF
--- a/.github/workflows/validate_config.yml
+++ b/.github/workflows/validate_config.yml
@@ -9,17 +9,22 @@ on:
       - main
 
 jobs:
-  preset:
+  validate-config:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - default.json
+          - no-grouping.json
 
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
-      - name: Validate config 
+      - name: Validate ${{ matrix.config }} config
         run: |
           docker run \
             --entrypoint=renovate-config-validator \
             --volume "$(pwd):/tmp" \
-            renovate/renovate:slim /tmp/default.json
+            renovate/renovate:slim /tmp/${{ matrix.config }}

--- a/no-grouping.json
+++ b/no-grouping.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Preset for use with CDS repos that disables patch and minor update grouping",
+  "extends": [
+    "config:base",
+    ":maintainLockFilesWeekly",
+    ":rebaseStalePrs",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    "docker:enableMajor",
+    "docker:pinDigests",
+    "group:linters",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "schedule": [
+    "every weekend"
+  ],
+  "timezone": "America/Montreal",
+  "automergeType": "pr",
+  "prCreation": "not-pending",
+  "platformAutomerge": false,
+  "internalChecksFilter": "strict",
+  "labels": [
+    "Dependencies",
+    "Renovate"
+  ],
+  "prBodyNotes": [
+    "### Review \n- [ ] Updates have been tested and work \n- [ ] If updates are AWS related, versions match the infrastructure (e.g. Lambda runtime, database, etc.)"
+  ],
+  "ignoreDeps": [
+    "bridgecrewio/checkov-action",
+    "public.ecr.aws/lambda/python"
+  ],
+  "pip_requirements": {
+    "fileMatch": [
+      "(^|/)([\\w-]*)requirements([\\w-]*)\\.(txt|pip|in)$"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "python"
+      ],
+      "versioning": "pep440"
+    },
+    {
+      "description": "Group all non-major GitHub actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major github action dependencies",
+      "groupSlug": "all-non-major-github-action"
+    },
+    {
+      "description": "Group all non-major Docker images",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major docker images",
+      "groupSlug": "all-non-major-docker-images"
+    },
+    {
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "One week stability period for minor, patch, digest and lockFileMaintenance",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "lockFileMaintenance"
+      ],
+      "stabilityDays": 7
+    },
+    {
+      "description": "v prefix workaround for action updates",
+      "matchDepTypes": [
+        "action"
+      ],
+      "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "Group prettier packages",
+      "matchPackageNames": [
+        "prettier"
+      ],
+      "matchPackagePatterns": [
+        "^@prettier\\/",
+        "^prettier-plugin-"
+      ],
+      "groupName": "prettier packages"
+    },
+    {
+      "description": "Require approval for aws-sdk as it updates too often",
+      "matchPackageNames": [
+        "aws-sdk"
+      ],
+      "matchPackagePatterns": [
+        "^@aws-sdk\\/"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Creates a Renovate config that does not group patch and minor dependency updates.

This is being done to support Poetry, which struggles with performing dependency resolution when there are multiple grouped dependency changes.

# Related
- cds-snc/platform-core-services#287