### PR TITLE
Adding ignorePaths to exclude sre synced files to the renovate global config

### DIFF
--- a/default.json
+++ b/default.json
@@ -37,6 +37,11 @@
       "(^|/)([\\w-]*)requirements([\\w-]*)\\.(txt|pip|in)$"
     ]
   },
+  "ignorePaths": [
+    ".github/workflows/s3-backup.yml",
+    ".github/workflows/ossf-scorecard.yml",
+    ".github/workflows/export_github_data.yml"
+  ],
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
# Summary | Résumé

Adding conditions to exclude the sre synced github workflows as they are synced by the sre sync. 