### PR TITLE
chore: ignore Backstage catalog helper workflow

### DIFF
--- a/default.json
+++ b/default.json
@@ -40,7 +40,8 @@
   "ignorePaths": [
     ".github/workflows/s3-backup.yml",
     ".github/workflows/ossf-scorecard.yml",
-    ".github/workflows/export_github_data.yml"
+    ".github/workflows/export_github_data.yml",
+    ".github/workflows/backstage-catalog-helper.yml"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
# Summary
Update the default config to ignore the Backstage catalog helper.  This will be managed by the SRE file sync.