### PR TITLE
fix: exclude pinning of devcontainer features

### DIFF
--- a/default.json
+++ b/default.json
@@ -96,6 +96,9 @@
       "matchDatasources": [
         "docker"
       ],
+      "matchDepTypes": [
+        "image"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch",


### PR DESCRIPTION
# Summary
Update the Docker package rule to only pin Docker images.  Currently it's also attempting to pin devcontainer `features` which breaks the devcontainer build.

# Related
- https://github.com/cds-snc/terraform-modules/pull/492
- https://github.com/renovatebot/renovate/issues/28781
- https://github.com/renovatebot/renovate/pull/28792