### PR TITLE
fix: docker pin digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,6 @@
     ":semanticCommits",
     ":semanticCommitScope(deps)",
     "docker:enableMajor",
-    "docker:pinDigests",
     "group:linters",
     "helpers:pinGitHubActionDigests"
   ],
@@ -109,6 +108,18 @@
       ],
       "groupName": "all non-major docker images",
       "groupSlug": "all-non-major-docker-images"
+    },
+    {
+      "description": "Pin all Docker digests",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchDepTypes": [
+        "image"
+      ],
+      "pinDigests": true,
+      "groupName": "docker pin digests",
+      "groupSlug": "docker-pin-digests"
     },
     {
       "description": "Require dashboard approval for major updates",


### PR DESCRIPTION
# Summary
Replace the default `docker:pinDigest` config with a custom package rule that limits the behaviour to
only Docker images.

This will prevent Renovate from trying to pin devcontainer feature's to a git commit SHA, which is a breaking behaviour.

# Related
- https://docs.renovatebot.com/presets-docker/#dockerpindigests
